### PR TITLE
Fix dark mode toggle icons

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -34,10 +34,22 @@ export default function Navbar({ darkMode, toggleLang, toggleDark }) {
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
-      fill="currentColor"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
       className="w-6 h-6"
     >
-      <path d="M12 4.5..." />
+      <circle cx="12" cy="12" r="4" fill="currentColor" />
+      <line x1="12" y1="2" x2="12" y2="6" />
+      <line x1="12" y1="18" x2="12" y2="22" />
+      <line x1="4.22" y1="4.22" x2="6.34" y2="6.34" />
+      <line x1="17.66" y1="17.66" x2="19.78" y2="19.78" />
+      <line x1="2" y1="12" x2="6" y2="12" />
+      <line x1="18" y1="12" x2="22" y2="12" />
+      <line x1="4.22" y1="19.78" x2="6.34" y2="17.66" />
+      <line x1="17.66" y1="6.34" x2="19.78" y2="4.22" />
     </svg>
   );
   const Moon = (
@@ -47,7 +59,7 @@ export default function Navbar({ darkMode, toggleLang, toggleDark }) {
       fill="currentColor"
       className="w-6 h-6"
     >
-      <path d="M21 12.79..." />
+      <path d="M21.752 15.002A9 9 0 1111.998 2.248a7 7 0 109.754 12.754z" />
     </svg>
   );
   const Hamburger = (


### PR DESCRIPTION
## Summary
- replace placeholder SVG paths with real sun and moon icons for the dark mode toggle

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c03552f70832c8cc1c22e689d397c