### PR TITLE
Fix dark mode toggle icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="tr">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -20,7 +20,35 @@ export default function Navbar({ darkMode, toggleLang, toggleDark }) {
   const opacity = scrolled ? "bg-opacity-80" : "";
   const bgClasses = `${base} ${themeBg} ${opacity}`;
 
-  const switchFlag = i18n.language === "en" ? "🇹🇷" : "🇬🇧";
+  const TRFlag = (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 36 24"
+      className="w-6 h-6"
+    >
+      <rect width="36" height="24" fill="#e30a17" />
+      <circle cx="14" cy="12" r="6" fill="#fff" />
+      <circle cx="16" cy="12" r="5" fill="#e30a17" />
+      <polygon
+        fill="#fff"
+        points="21,15 20.29,12.97 18.15,12.93 19.86,11.63 19.24,9.57 21,10.8 22.76,9.57 22.14,11.63 23.85,12.93 21.71,12.97"
+      />
+    </svg>
+  );
+
+  const ENFlag = (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 36 24"
+      className="w-6 h-6"
+    >
+      <rect width="36" height="24" fill="#fff" />
+      <rect x="14" width="8" height="24" fill="#ce1126" />
+      <rect y="8" width="36" height="8" fill="#ce1126" />
+    </svg>
+  );
+
+  const switchFlag = i18n.language === "en" ? TRFlag : ENFlag;
   const menuItems = [
     "home",
     "products",
@@ -34,10 +62,22 @@ export default function Navbar({ darkMode, toggleLang, toggleDark }) {
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
-      fill="currentColor"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
       className="w-6 h-6"
     >
-      <path d="M12 4.5..." />
+      <circle cx="12" cy="12" r="4" fill="currentColor" />
+      <line x1="12" y1="2" x2="12" y2="6" />
+      <line x1="12" y1="18" x2="12" y2="22" />
+      <line x1="4.22" y1="4.22" x2="6.34" y2="6.34" />
+      <line x1="17.66" y1="17.66" x2="19.78" y2="19.78" />
+      <line x1="2" y1="12" x2="6" y2="12" />
+      <line x1="18" y1="12" x2="22" y2="12" />
+      <line x1="4.22" y1="19.78" x2="6.34" y2="17.66" />
+      <line x1="17.66" y1="6.34" x2="19.78" y2="4.22" />
     </svg>
   );
   const Moon = (
@@ -47,7 +87,7 @@ export default function Navbar({ darkMode, toggleLang, toggleDark }) {
       fill="currentColor"
       className="w-6 h-6"
     >
-      <path d="M21 12.79..." />
+      <path d="M21.752 15.002A9 9 0 1111.998 2.248a7 7 0 109.754 12.754z" />
     </svg>
   );
   const Hamburger = (
@@ -84,15 +124,20 @@ export default function Navbar({ darkMode, toggleLang, toggleDark }) {
               {t(`nav.${item}`)}
             </a>
           ))}
-          <button onClick={toggleLang} className="font-semibold text-2xl">
-            {switchFlag}
-          </button>
-          <button
-            onClick={toggleDark}
-            className="p-2 rounded bg-gray-200 dark:bg-gray-700"
-          >
-            {darkMode ? Sun : Moon}
-          </button>
+          <div className="flex items-center space-x-2">
+            <button
+              onClick={toggleLang}
+              className="p-2 rounded bg-gray-200 dark:bg-gray-700"
+            >
+              {switchFlag}
+            </button>
+            <button
+              onClick={toggleDark}
+              className="p-2 rounded bg-gray-200 dark:bg-gray-700"
+            >
+              {darkMode ? Sun : Moon}
+            </button>
+          </div>
         </div>
         <button
           className="md:hidden p-2"
@@ -114,7 +159,10 @@ export default function Navbar({ darkMode, toggleLang, toggleDark }) {
               </a>
             ))}
             <div className="flex items-center space-x-4">
-              <button onClick={toggleLang} className="font-semibold text-2xl">
+              <button
+                onClick={toggleLang}
+                className="p-2 rounded bg-gray-200 dark:bg-gray-700"
+              >
                 {switchFlag}
               </button>
               <button

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -8,8 +8,8 @@ i18n.use(initReactI18next).init({
     en: { translation: en },
     tr: { translation: tr },
   },
-  lng: 'en',
-  fallbackLng: 'en',
+  lng: 'tr',
+  fallbackLng: 'tr',
   interpolation: { escapeValue: false },
 });
 


### PR DESCRIPTION
## Summary
- add inline Turkish/English flag SVGs and group language + dark-mode buttons for consistent navbar alignment
- default application language to Turkish and mark HTML root accordingly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c03552f70832c8cc1c22e689d397c