### PR TITLE
Refine services section and background video handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -60,17 +60,28 @@ export default function App() {
         }, {})
     );
 
-    // Video yüklenme takibi (white flash fix)
+    // Ürünler bölümünü gözlemle ve video kaynağını buna göre ayarla
     const [videoLoaded, setVideoLoaded] = useState(true);
-    const videoSrc = activeSection === "products"
+    const [productInView, setProductInView] = useState(false);
+    const videoSrc = productInView
         ? "/videos/hero.mp4"
         : "/videos/dna-bg-video2.mp4";
-    const poster = activeSection === "products"
-        ? "/images/hero-poster.jpg" // varsa, yoksa dna-bg-video2 posterini kullan
+    const poster = productInView
+        ? "/images/hero-poster.jpg"
         : "/images/bg-mobile.jpg";
     useEffect(() => {
         setVideoLoaded(false);
     }, [videoSrc]);
+    useEffect(() => {
+        const ref = sectionRefs.current.products.current;
+        if (!ref) return;
+        const observer = new IntersectionObserver(
+            ([entry]) => setProductInView(entry.intersectionRatio > 0.5),
+            { threshold: [0.5] }
+        );
+        observer.observe(ref);
+        return () => observer.disconnect();
+    }, []);
 
     useEffect(() => {
         const handleScroll = () => {
@@ -116,11 +127,10 @@ export default function App() {
             />
             {/* Video yüklenene kadar poster arka plan */}
             <div
-                className={`fixed inset-0 w-full h-full -z-20 pointer-events-none select-none transition-all duration-150`}
+                className="fixed inset-0 w-full h-full -z-20 pointer-events-none select-none bg-black"
                 style={{
                     background: `url(${poster}) center center / cover no-repeat`,
-                    opacity: videoLoaded ? 0 : 1,
-                    transition: "opacity 0.15s"
+                    opacity: videoLoaded ? 0 : 1
                 }}
             />
             {/* Background video - sadece src değişiyor, başka hiçbir efekt yok */}
@@ -131,11 +141,9 @@ export default function App() {
                 playsInline
                 aria-hidden="true"
                 poster={poster}
-                className="fixed inset-0 w-full h-full object-cover -z-10 pointer-events-none select-none"
+                className="fixed inset-0 w-full h-full object-cover -z-10 pointer-events-none select-none bg-black"
                 style={{
-                    filter: darkMode
-                        ? "brightness(1) saturate(2) sepia(1) hue-rotate(80deg)"
-                        : "invert(1) hue-rotate(120deg)"
+                    filter: darkMode ? "brightness(0.5)" : "none"
                 }}
                 key={videoSrc}
                 onLoadedData={() => setVideoLoaded(true)}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -34,6 +34,7 @@
   },
   "services": {
     "title": "Our Services",
+    "intro": "From genetic planning to on-farm training, we provide end-to-end solutions for your herd.",
     "list": [
       {
         "title": "Genetic Consulting",
@@ -46,6 +47,18 @@
       {
         "title": "Embryo Transfer",
         "description": "Modern embryo transfer solutions to multiply superior genetics quickly."
+      },
+      {
+        "title": "Reproductive Management",
+        "description": "Comprehensive breeding management and tracking service."
+      },
+      {
+        "title": "Nutrition Planning",
+        "description": "Tailored nutrition programs to maximize yield and health."
+      },
+      {
+        "title": "Training & Support",
+        "description": "On-site training and continuous technical assistance for your team."
       }
     ]
   },

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -34,6 +34,7 @@
   },
   "services": {
     "title": "Hizmetlerimiz",
+    "intro": "Genetik planlamadan çiftlik içi eğitime kadar sürünüz için uçtan uca çözümler sunuyoruz.",
     "list": [
       {
         "title": "Genetik Danışmanlık",
@@ -46,6 +47,18 @@
       {
         "title": "Embriyo Transferi",
         "description": "Üstün genetik potansiyeli hızla çoğaltmak için modern embriyo transferi çözümleri."
+      },
+      {
+        "title": "Üreme Yönetimi",
+        "description": "Çiftleşme takibi ve doğum planlamasını kapsayan kapsamlı üreme yönetimi."
+      },
+      {
+        "title": "Beslenme Planlaması",
+        "description": "Verimi maksimize etmek için sürünüze özel beslenme programları."
+      },
+      {
+        "title": "Eğitim ve Destek",
+        "description": "Çiftlik personeline yerinde eğitim ve sürekli teknik destek."
       }
     ]
   },

--- a/src/sections/Services.jsx
+++ b/src/sections/Services.jsx
@@ -7,16 +7,24 @@ export default function Services() {
 
   return (
     <section id="services" className="scroll-mt-16 min-h-screen px-6 py-12 relative">
-      <h2 className="text-4xl font-semibold mb-8 text-center text-gray-900 dark:text-gray-200">
+      <h2 className="text-4xl font-semibold mb-6 text-center text-gray-900 dark:text-gray-200">
         {t("services.title")}
       </h2>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+      <p className="max-w-3xl mx-auto mb-10 text-center text-lg text-gray-700 dark:text-gray-300">
+        {t("services.intro")}
+      </p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
         {services.map((service, idx) => (
-          <div key={idx} className="p-8 border rounded-lg bg-white/50 dark:bg-gray-700/50">
-            <h3 className="text-2xl font-medium mb-2 text-gray-900 dark:text-gray-200">
+          <div
+            key={idx}
+            className="p-8 rounded-lg shadow-lg bg-white/70 dark:bg-gray-700/60 border border-teal-200 dark:border-teal-600/50"
+          >
+            <h3 className="text-2xl font-semibold mb-3 text-teal-700 dark:text-teal-300">
               {service.title}
             </h3>
-            <p className="text-gray-700 dark:text-gray-300">{service.description}</p>
+            <p className="text-gray-700 dark:text-gray-300 leading-relaxed">
+              {service.description}
+            </p>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- Improve services section layout and copy, expanding to six detailed offerings
- Observe products section to switch background videos and remove blue tint/flash

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d5f8326ec832cb1913d75a1a66ed0