### PR TITLE
Use remote media and add service

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -57,7 +57,7 @@ export default function App() {
   // Video yüklenme takibi (white flash fix)
   const [videoLoaded, setVideoLoaded] = useState(true);
   const videoSrc = "/videos/dna-bg-video2.mp4";
-  const poster = "/images/bg-mobile.jpg";
+  const poster = "https://images.unsplash.com/photo-1595664652035-0956d50e0311?auto=compress&cs=tinysrgb&w=600";
   useEffect(() => {
     setVideoLoaded(false);
   }, [videoSrc]);
@@ -113,7 +113,11 @@ export default function App() {
           opacity: videoLoaded ? 0 : 1,
         }}
       />
-
+      {!videoLoaded && (
+        <div className="fixed inset-0 flex items-center justify-center -z-10 pointer-events-none">
+          <div className="w-10 h-10 border-4 border-teal-500 border-t-transparent rounded-full animate-spin" />
+        </div>
+      )}
 
       {/* background video with only the sepia/hue-rotate on darkMode;
           light mode has NO hue-rotate (→ no blue tint) */}

--- a/src/sections/Blog.jsx
+++ b/src/sections/Blog.jsx
@@ -4,19 +4,19 @@ import React from "react";
 const posts = [
   {
     title: "Yeni Suni Tohumlama Teknikleri",
-    img: "/images/blog/tohumlama.jpg",
+    img: "https://images.unsplash.com/photo-1502590464431-3b66d77494d7?auto=compress&cs=tinysrgb&w=800",
     excerpt: "Modern laboratuvar şartlarında verim optimizasyonu...",
     link: "#"
   },
   {
     title: "Çiftlikte Sağlık Takibi",
-    img: "/images/blog/saglik.jpg",
+    img: "https://images.unsplash.com/photo-1530268782463-418534b0affa?auto=compress&cs=tinysrgb&w=800",
     excerpt: "Hayvan sağlığı verilerini düzenli takip ederek hastalıkları erkenden tespit edin...",
     link: "#"
   },
   {
     title: "Genetik Seçim Stratejileri",
-    img: "/images/blog/genetik.jpg",
+    img: "https://images.unsplash.com/photo-1573646609328-01f50a125c0c?auto=compress&cs=tinysrgb&w=800",
     excerpt: "Irk seçiminin süt ve et verimine etkisi üzerine bilimsel makale özeti...",
     link: "#"
   },
@@ -30,7 +30,7 @@ export default function Blog() {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
           {posts.map(p => (
             <a key={p.title} href={p.link} className="block bg-white rounded-xl shadow-md overflow-hidden hover:shadow-lg dark:bg-neutral-800">
-              <img src={p.img} alt={p.title} className="w-full h-48 object-cover" />
+              <img src={p.img} alt={p.title} className="w-full h-48 object-cover" loading="lazy" />
               <div className="p-4">
                 <h3 className="text-xl font-semibold mb-2 text-teal-700 dark:text-teal-300">{p.title}</h3>
                 <p className="text-gray-700 dark:text-gray-300 text-sm">{p.excerpt}</p>

--- a/src/sections/Partners.jsx
+++ b/src/sections/Partners.jsx
@@ -2,10 +2,10 @@
 import React from "react";
 
 const partners = [
-  "/images/partners/bayer.png",
-  "/images/partners/collins.png",
-  "/images/partners/semex.png",
-  "/images/partners/other.png"
+  "https://logo.clearbit.com/bayer.com",
+  "https://logo.clearbit.com/collins.com",
+  "https://logo.clearbit.com/semex.com",
+  "https://placehold.co/150x80?text=Logo",
 ];
 
 export default function Partners() {
@@ -20,6 +20,7 @@ export default function Partners() {
               src={logo}
               alt={`Partner ${i + 1}`}
               className="h-16 object-contain filter grayscale hover:filter-none transition"
+              loading="lazy"
             />
           ))}
         </div>

--- a/src/sections/Products.jsx
+++ b/src/sections/Products.jsx
@@ -1,29 +1,83 @@
 // src/sections/Products.jsx
-import React from "react";
+import React, { useState } from "react";
 
 const products = [
-  { name: "Holstein Dişi",          image: "/images/products/holstein-disi.jpg",        desc: "Yüksek verimli Holstein dişi genomları." },
-  { name: "Holstein",               image: "/images/products/holstein.jpg",             desc: "Dünyaca ünlü süt verimi taçlı Holstein hattı." },
-  { name: "Montbéliarde",           image: "/images/products/montbeliarde.jpg",         desc: "Sağlam dizi ve yüksek süt verimi için Montbéliarde." },
-  { name: "Montbéliarde Dişi",      image: "/images/products/montbeliarde-disi.jpg",    desc: "Seçkin Montbéliarde dişi genomları." },
-  { name: "Brown Swiss (Montofon)",  image: "/images/products/brown-swiss-montofon.jpg", desc: "Dayanıklı Brown Swiss (Montofon) genomları." },
-  { name: "Etçi Boğalar",           image: "/images/products/etci-bogalar.jpg",         desc: "En iyi etçi boğalarla damızlık iyileştirme." },
-  { name: "Kırmızı Holstein",       image: "/images/products/kirmizi-holstein.jpg",     desc: "Güçlü ve renkli Kırmızı Holstein genomları." },
-  { name: "Jersey",                 image: "/images/products/jersey.jpg",               desc: "Yoğun yağlı süt için seçkin Jersey hattı." },
-  { name: "Simmental",              image: "/images/products/simmental.jpg",            desc: "Çift yönlü verim: Et & süt için Simmental." },
+  {
+    name: "Holstein Dişi",
+    image:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Holstein_Friesian_UK_Yorkshire_July_2011.jpg/960px-Holstein_Friesian_UK_Yorkshire_July_2011.jpg",
+    desc: "Yüksek verimli Holstein dişi genomları.",
+  },
+  {
+    name: "Holstein",
+    image:
+      "https://images.unsplash.com/photo-1527153857715-3908f2bae5e8?auto=compress&cs=tinysrgb&w=800",
+    desc: "Dünyaca ünlü süt verimi taçlı Holstein hattı.",
+  },
+  {
+    name: "Montbéliarde",
+    image:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Vache_Montb%C3%A9liarde.jpg/960px-Vache_Montb%C3%A9liarde.jpg",
+    desc: "Sağlam dizi ve yüksek süt verimi için Montbéliarde.",
+  },
+  {
+    name: "Montbéliarde Dişi",
+    image:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Vache_Montb%C3%A9liarde.jpg/1200px-Vache_Montb%C3%A9liarde.jpg",
+    desc: "Seçkin Montbéliarde dişi genomları.",
+  },
+  {
+    name: "Brown Swiss (Montofon)",
+    image: "https://upload.wikimedia.org/wikipedia/commons/e/e9/Brown_swiss.jpg",
+    desc: "Dayanıklı Brown Swiss (Montofon) genomları.",
+  },
+  {
+    name: "Etçi Boğalar",
+    image:
+      "https://upload.wikimedia.org/wikipedia/commons/b/b5/A_Friesian_Bull%2C_Llandeilo_Graban_-_geograph.org.uk_-_579885.jpg",
+    desc: "En iyi etçi boğalarla damızlık iyileştirme.",
+  },
+  {
+    name: "Kırmızı Holstein",
+    image:
+      "https://images.unsplash.com/photo-1561043394-9f7d16d9ae37?auto=compress&cs=tinysrgb&w=800",
+    desc: "Güçlü ve renkli Kırmızı Holstein genomları.",
+  },
+  {
+    name: "Jersey",
+    image:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/5/55/Bou%C3%ABts_d%27J%C3%A8rri_%C3%8Agypte_5_J%C3%A8rri_Mai_2009.jpg/960px-Bou%C3%ABts_d%27J%C3%A8rri_Mai_2009.jpg",
+    desc: "Yoğun yağlı süt için seçkin Jersey hattı.",
+  },
+  {
+    name: "Simmental",
+    image:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a6/Simmentaler_Fleckvieh.jpg/960px-Simmentaler_Fleckvieh.jpg",
+    desc: "Çift yönlü verim: Et & süt için Simmental.",
+  },
 ];
 
 export default function Products() {
+  const [videoLoaded, setVideoLoaded] = useState(false);
   return (
     <section id="products" className="relative h-screen pt-16 bg-transparent overflow-hidden">
       {/* hero.mp4 sadece bu bölüm için */}
       <video
-        autoPlay loop muted playsInline
-        poster="/images/hero-poster.jpg"
+        autoPlay
+        loop
+        muted
+        playsInline
+        poster="https://images.unsplash.com/photo-1546445317-29f4545e9d53?auto=compress&cs=tinysrgb&w=1600"
         className="absolute inset-0 w-full h-full object-cover -z-20"
+        onLoadedData={() => setVideoLoaded(true)}
       >
         <source src="/videos/hero.mp4" type="video/mp4" />
       </video>
+      {!videoLoaded && (
+        <div className="absolute inset-0 flex items-center justify-center z-0 pointer-events-none">
+          <div className="w-10 h-10 border-4 border-teal-500 border-t-transparent rounded-full animate-spin" />
+        </div>
+      )}
 
       {/* yarı saydam okunabilirlik katmanı */}
       <div className="absolute inset-0 bg-white bg-opacity-60 backdrop-blur-sm dark:bg-neutral-900 dark:bg-opacity-60 -z-10" />

--- a/src/sections/Services.jsx
+++ b/src/sections/Services.jsx
@@ -32,7 +32,22 @@ const services = [
     ),
     desc: "En yeni tekniklerle yüksek verimli damızlık hizmeti."
   },
-  // …add more…
+  {
+    title: "Embriyo Transferi",
+    icon: (
+      <svg
+        className="w-12 h-12 text-green-800 dark:text-green-300 mb-4"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        viewBox="0 0 24 24"
+      >
+        <path d="M12 2a10 10 0 100 20 10 10 0 000-20z" />
+        <path d="M12 6v6l4 2" />
+      </svg>
+    ),
+    desc: "Yüksek başarı oranlı embriyo transfer çözümleri.",
+  },
 ];
 
 export default function Services() {


### PR DESCRIPTION
## Summary
- swap local image references for remote URLs and enable lazy loading
- show spinners while background and hero videos load
- extend service list with Embriyo Transferi item

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688fd5b0c20c832ca17a27e71cb5c738