### PR TITLE
Fix mobile layout and autoplay issues

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,8 +58,19 @@ export default function App() {
   const [videoLoaded, setVideoLoaded] = useState(true);
   const videoSrc = "/videos/dna-bg.mp4";
   const placeholderColor = "#1a1a1a"; // dark grey fallback main
+  const bgVideoRef = useRef(null);
   useEffect(() => {
     setVideoLoaded(false);
+  }, [videoSrc]);
+
+  // Ensure autoplay on iOS devices
+  useEffect(() => {
+    if (bgVideoRef.current) {
+      const playPromise = bgVideoRef.current.play();
+      if (playPromise?.catch) {
+        playPromise.catch(() => {});
+      }
+    }
   }, [videoSrc]);
 
   useEffect(() => {
@@ -119,6 +130,7 @@ export default function App() {
       {/* background video with only the sepia/hue-rotate on darkMode;
           light mode has NO hue-rotate (→ no blue tint) */}
       <video
+        ref={bgVideoRef}
         autoPlay
         loop
         muted

--- a/src/sections/Blog.jsx
+++ b/src/sections/Blog.jsx
@@ -24,7 +24,7 @@ const posts = [
 
 export default function Blog() {
   return (
-    <section id="blog" className="h-[100vh] py-20">
+    <section id="blog" className="min-h-screen py-20">
       <div className="max-w-5xl mx-auto px-6">
         <h2 className="text-4xl font-bold mb-8 text-center">Blog & Haberler</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">

--- a/src/sections/Hero.jsx
+++ b/src/sections/Hero.jsx
@@ -7,7 +7,7 @@ export default function Hero({ darkMode }) {
   return (
     <section
       id="home"
-      className="relative h-[100vh] flex flex-col items-center justify-center pt-16 overflow-hidden select-none"
+      className="relative min-h-screen flex flex-col pt-16 pb-12 overflow-hidden select-none"
     >
       {/* Karartma layer (gece/gündüz efekti) */}
       <div
@@ -21,7 +21,7 @@ export default function Hero({ darkMode }) {
       <div className="absolute inset-0 z-0 pointer-events-none backdrop-blur-[2px]" />
 
       {/* Content */}
-      <div className="relative z-10 flex flex-col items-center justify-center w-full h-full text-center px-6">
+      <div className="relative z-10 flex-1 flex flex-col items-center justify-center w-full text-center px-6">
         <h1 className="text-5xl sm:text-6xl md:text-7xl font-bold mb-5 text-green-900 dark:text-green-300 drop-shadow-xl tracking-tight">
           Duru<span className="text-teal-600 dark:text-teal-300">genetik</span>
         </h1>
@@ -37,9 +37,16 @@ export default function Hero({ darkMode }) {
         </a>
       </div>
       {/* Aşağı ok animasyonu */}
-      <div className="absolute bottom-8 left-1/2 -translate-x-1/2 z-20">
+      <div className="z-20 flex justify-center">
         <a href="#products" aria-label="Scroll to products" className="animate-bounce">
-          <svg width="38" height="38" fill="none" stroke="currentColor" strokeWidth={2} className="text-teal-600 dark:text-teal-300">
+          <svg
+            width="38"
+            height="38"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            className="text-teal-600 dark:text-teal-300"
+          >
             <circle cx="19" cy="19" r="17" strokeOpacity=".15" />
             <path d="M12 18l7 7 7-7" strokeLinecap="round" strokeLinejoin="round" />
             <path d="M19 10v14" strokeLinecap="round" />

--- a/src/sections/Partners.jsx
+++ b/src/sections/Partners.jsx
@@ -10,7 +10,7 @@ const partners = [
 
 export default function Partners() {
   return (
-    <section id="partners" className="py-20 h-[100vh] bg-transparent">
+    <section id="partners" className="py-20 min-h-screen bg-transparent">
       <div className="max-w-5xl mx-auto px-6 text-center">
         <h2 className="text-4xl font-bold mb-8">İş Ortaklarımız</h2>
         <div className="flex flex-wrap justify-center items-center gap-8">

--- a/src/sections/Products.jsx
+++ b/src/sections/Products.jsx
@@ -60,7 +60,7 @@ const products = [
 export default function Products() {
   const [videoLoaded, setVideoLoaded] = useState(false);
   return (
-    <section id="products" className="relative h-screen pt-16 bg-transparent overflow-hidden">
+    <section id="products" className="relative min-h-screen pt-16 pb-12 bg-transparent overflow-hidden">
       {/* hero.mp4 sadece bu bölüm için */}
       <video
         autoPlay
@@ -82,15 +82,36 @@ export default function Products() {
       {/* yarı saydam okunabilirlik katmanı */}
       <div className="absolute inset-0 bg-white bg-opacity-60 backdrop-blur-sm dark:bg-neutral-900 dark:bg-opacity-60 -z-10" />
 
-      <div className="relative z-10 flex flex-col items-center justify-center h-full px-6">
+      <div className="relative z-10 flex flex-col items-center w-full px-6 py-12">
         <h2 className="text-4xl font-bold mb-8 text-gray-900 dark:text-white">
           Ürünlerimiz
         </h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl w-full mx-auto">
+        <div className="hidden sm:grid grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl w-full mx-auto">
           {products.map((prod) => (
             <div
               key={prod.name}
               className="flex flex-col items-center p-6 bg-white bg-opacity-60 backdrop-blur-md rounded-xl shadow-lg dark:bg-neutral-800 dark:bg-opacity-60"
+            >
+              <img
+                src={prod.image}
+                alt={prod.name}
+                className="w-40 h-40 object-cover rounded-full mb-4 border-4 border-teal-300 dark:border-teal-600 shadow"
+                loading="lazy"
+              />
+              <h3 className="text-lg font-bold text-teal-900 dark:text-teal-300 mb-1">
+                {prod.name}
+              </h3>
+              <p className="text-sm text-gray-700 dark:text-gray-200 text-center">
+                {prod.desc}
+              </p>
+            </div>
+          ))}
+        </div>
+        <div className="flex sm:hidden gap-6 overflow-x-auto snap-x snap-mandatory w-full pb-4">
+          {products.map((prod) => (
+            <div
+              key={prod.name}
+              className="min-w-[250px] flex-shrink-0 snap-center flex flex-col items-center p-6 bg-white bg-opacity-60 backdrop-blur-md rounded-xl shadow-lg dark:bg-neutral-800 dark:bg-opacity-60"
             >
               <img
                 src={prod.image}

--- a/src/sections/Services.jsx
+++ b/src/sections/Services.jsx
@@ -52,7 +52,7 @@ const services = [
 
 export default function Services() {
   return (
-    <section id="services" className="h-[100vh] py-20 bg-transparent">
+    <section id="services" className="min-h-screen py-20 bg-transparent">
       <div className="max-w-5xl mx-auto px-6 text-center">
         <h2 className="text-4xl font-bold mb-8 text-gray-900 dark:text-gray-100">
           Hizmetlerimiz


### PR DESCRIPTION
## Summary
- ensure hero section arrow stays visible by using flex layout
- trigger background video autoplay on iOS and clean up section heights
- add mobile slider for products and prevent section overlaps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fe5a4facc832cabea18815a167607