### PR TITLE
Center sections and auto-close mobile menu on theme/language change

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     />
     <title>DuruGenetik | Sürü Verimliliği İçin Genetik Çözümler</title>
   </head>
-  <body>
+  <body class="overflow-x-hidden">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -76,6 +76,12 @@ export default function Navbar({
         setThemeSwitching(true);
         setTimeout(() => setThemeSwitching(false), 350);
         toggleDark();
+        setMenuOpen(false);
+    }
+
+    function handleLangSwitch() {
+        toggleLang();
+        setMenuOpen(false);
     }
 
     const sunIcon = (
@@ -169,7 +175,7 @@ export default function Navbar({
                     </div>
                     {/* DIL BUTTON */}
                     <button
-                        onClick={toggleLang}
+                        onClick={handleLangSwitch}
                         className={switchBtnClass}
                         aria-label={switchLabel}
                         title={switchLabel}
@@ -228,7 +234,7 @@ export default function Navbar({
                         ))}
                         <div className="flex items-center space-x-4">
                             <button
-                                onClick={toggleLang}
+                                onClick={handleLangSwitch}
                                 className={switchBtnClass}
                                 aria-label={switchLabel}
                                 title={switchLabel}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -52,7 +52,7 @@ export default function Navbar({
     }, [activeSection, menuItems]);
 
     // FULL DÜZ RENK (asla opacity, blur, overlay, vs yok)
-    const base = "fixed top-0 left-0 w-full z-30 transition-colors";
+    const base = "fixed top-0 left-0 w-screen z-30 transition-colors";
     const themeBg = darkMode ? "bg-neutral-900" : "bg-white";
     const bgClasses = `${base} ${themeBg}`;
 
@@ -131,7 +131,7 @@ export default function Navbar({
 
     return (
         <nav className={bgClasses}>
-            <div className="max-w-6xl mx-auto px-6 flex justify-between items-center h-16">
+            <div className="max-w-6xl w-full mx-auto px-6 flex justify-between items-center h-16">
                 {/* Logo */}
                 <span className="font-extrabold text-2xl flex">
                     <span className="text-green-800 dark:text-green-300">Duru</span>
@@ -210,7 +210,7 @@ export default function Navbar({
                 </button>
             </div>
             {menuOpen && (
-                <div className={`md:hidden ${darkMode ? "bg-neutral-900" : "bg-white"}`}>
+                <div className={`md:hidden w-full ${darkMode ? "bg-neutral-900" : "bg-white"}`}>
                     <div className="flex flex-col px-6 py-4 space-y-4">
                         {menuItems.map(({ id, label }) => (
                             <a

--- a/src/sections/About.jsx
+++ b/src/sections/About.jsx
@@ -3,8 +3,8 @@ import React from "react";
 
 export default function About() {
   return (
-    <section id="aboutus" className="min-h-screen flex items-center">
-      <div className="max-w-4xl mx-auto px-6 py-16 space-y-6 text-center">
+    <section id="aboutus" className="min-h-screen flex flex-col justify-center items-center scroll-mt-16">
+      <div className="max-w-4xl mx-auto px-6 space-y-6 text-center">
         <h2 className="text-4xl font-bold">Hakkımızda</h2>
         <p className="text-gray-700 dark:text-gray-300">
           <strong>Duru Genetik</strong> 2010’dan bu yana Burdur merkezli, veteriner medikal ve hayvan genetiği alanında uzman bir kuruluş. Çiftçilere

--- a/src/sections/About.jsx
+++ b/src/sections/About.jsx
@@ -3,8 +3,8 @@ import React from "react";
 
 export default function About() {
   return (
-    <section id="aboutus" className="h-[100vh] py-20">
-      <div className="max-w-4xl mx-auto px-6 space-y-6 text-center">
+    <section id="aboutus" className="min-h-screen flex items-center">
+      <div className="max-w-4xl mx-auto px-6 py-16 space-y-6 text-center">
         <h2 className="text-4xl font-bold">Hakkımızda</h2>
         <p className="text-gray-700 dark:text-gray-300">
           <strong>Duru Genetik</strong> 2010’dan bu yana Burdur merkezli, veteriner medikal ve hayvan genetiği alanında uzman bir kuruluş. Çiftçilere

--- a/src/sections/Approach.jsx
+++ b/src/sections/Approach.jsx
@@ -10,8 +10,8 @@ const steps = [
 
 export default function Approach() {
   return (
-    <section id="approach" className="min-h-screen flex items-center bg-transparent">
-      <div className="max-w-5xl mx-auto px-6 py-16">
+    <section id="approach" className="min-h-screen flex flex-col justify-center items-center bg-transparent scroll-mt-16">
+      <div className="max-w-5xl mx-auto px-6">
         <h2 className="text-4xl font-bold mb-12 text-center">Çalışma Prensibimiz</h2>
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           {steps.map(({ step, desc }) => (

--- a/src/sections/Approach.jsx
+++ b/src/sections/Approach.jsx
@@ -10,8 +10,8 @@ const steps = [
 
 export default function Approach() {
   return (
-    <section id="approach" className="h-[100vh] py-20 bg-transparent">
-      <div className="max-w-5xl mx-auto px-6">
+    <section id="approach" className="min-h-screen flex items-center bg-transparent">
+      <div className="max-w-5xl mx-auto px-6 py-16">
         <h2 className="text-4xl font-bold mb-12 text-center">Çalışma Prensibimiz</h2>
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           {steps.map(({ step, desc }) => (

--- a/src/sections/Blog.jsx
+++ b/src/sections/Blog.jsx
@@ -24,8 +24,8 @@ const posts = [
 
 export default function Blog() {
   return (
-    <section id="blog" className="min-h-screen flex items-center">
-      <div className="max-w-5xl mx-auto px-6 py-16">
+    <section id="blog" className="min-h-screen flex flex-col justify-center items-center scroll-mt-16">
+      <div className="max-w-5xl mx-auto px-6">
         <h2 className="text-4xl font-bold mb-8 text-center">Blog & Haberler</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
           {posts.map(p => (

--- a/src/sections/Blog.jsx
+++ b/src/sections/Blog.jsx
@@ -24,8 +24,8 @@ const posts = [
 
 export default function Blog() {
   return (
-    <section id="blog" className="min-h-screen py-20">
-      <div className="max-w-5xl mx-auto px-6">
+    <section id="blog" className="min-h-screen flex items-center">
+      <div className="max-w-5xl mx-auto px-6 py-16">
         <h2 className="text-4xl font-bold mb-8 text-center">Blog & Haberler</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
           {posts.map(p => (

--- a/src/sections/Contact.jsx
+++ b/src/sections/Contact.jsx
@@ -3,8 +3,8 @@ import React from "react";
 
 export default function Contact() {
   return (
-    <section id="contact" className="min-h-screen flex items-center bg-transparent">
-      <div className="max-w-3xl mx-auto px-6 py-16 text-gray-900 dark:text-gray-100">
+    <section id="contact" className="min-h-screen flex flex-col justify-center items-center bg-transparent scroll-mt-16">
+      <div className="max-w-3xl mx-auto px-6 text-gray-900 dark:text-gray-100">
         <h2 className="text-4xl font-bold mb-8 text-center">
           İletişim
         </h2>

--- a/src/sections/Contact.jsx
+++ b/src/sections/Contact.jsx
@@ -3,8 +3,8 @@ import React from "react";
 
 export default function Contact() {
   return (
-    <section id="contact" className="h-[100vh] py-20 bg-transparent">
-      <div className="max-w-3xl mx-auto px-6 text-gray-900 dark:text-gray-100">
+    <section id="contact" className="min-h-screen flex items-center bg-transparent">
+      <div className="max-w-3xl mx-auto px-6 py-16 text-gray-900 dark:text-gray-100">
         <h2 className="text-4xl font-bold mb-8 text-center">
           İletişim
         </h2>

--- a/src/sections/Hero.jsx
+++ b/src/sections/Hero.jsx
@@ -7,7 +7,7 @@ export default function Hero({ darkMode }) {
   return (
     <section
       id="home"
-      className="relative min-h-[calc(100vh-64px)] flex items-center justify-center pt-16 pb-12 overflow-hidden select-none"
+      className="relative min-h-screen flex items-center justify-center overflow-hidden select-none"
     >
       {/* Üstten çok hafif bir blur/fade */}
       <div className="absolute inset-0 z-0 pointer-events-none backdrop-blur-[2px]" />

--- a/src/sections/Partners.jsx
+++ b/src/sections/Partners.jsx
@@ -22,8 +22,8 @@ const partnersRow2 = [
 
 export default function Partners() {
   return (
-    <section id="partners" className="min-h-screen flex items-center bg-transparent">
-      <div className="max-w-5xl mx-auto px-6 py-16 text-center">
+    <section id="partners" className="min-h-screen flex flex-col justify-center items-center bg-transparent scroll-mt-16">
+      <div className="max-w-5xl mx-auto px-6 text-center">
         <h2 className="text-4xl font-bold mb-12">İş Ortaklarımız</h2>
         <div className="flex flex-col gap-8">
           <Marquee

--- a/src/sections/Partners.jsx
+++ b/src/sections/Partners.jsx
@@ -22,8 +22,8 @@ const partnersRow2 = [
 
 export default function Partners() {
   return (
-    <section id="partners" className="py-20 min-h-screen bg-transparent">
-      <div className="max-w-5xl mx-auto px-6 text-center">
+    <section id="partners" className="min-h-screen flex items-center bg-transparent">
+      <div className="max-w-5xl mx-auto px-6 py-16 text-center">
         <h2 className="text-4xl font-bold mb-12">İş Ortaklarımız</h2>
         <div className="flex flex-col gap-8">
           <Marquee

--- a/src/sections/Partners.jsx
+++ b/src/sections/Partners.jsx
@@ -22,41 +22,45 @@ const partnersRow2 = [
 
 export default function Partners() {
   return (
-    <section id="partners" className="min-h-screen flex flex-col justify-center items-center bg-transparent scroll-mt-16">
-      <div className="max-w-5xl mx-auto px-6 text-center">
-        <h2 className="text-4xl font-bold mb-12">İş Ortaklarımız</h2>
-        <div className="flex flex-col gap-8">
+    <section
+      id="partners"
+      className="min-h-screen flex flex-col justify-center items-center bg-transparent scroll-mt-16"
+    >
+      <div className="w-full px-4 sm:px-6 text-center">
+        <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-12">İş Ortaklarımız</h2>
+        <div className="flex flex-col gap-6 md:gap-8">
           <Marquee
             direction="right"
             speed={30}
             pauseOnHover
             pauseOnClick
             gradient={false}
-            className="flex items-center gap-8"
+            className="flex items-center gap-4 md:gap-8"
           >
             {partnersRow1.map((logo, i) => (
               <img
                 key={i}
                 src={logo}
                 alt={`Partner ${i + 1}`}
-                className="h-20 md:h-24 w-auto object-contain mx-8 filter grayscale hover:filter-none transition"
+                className="h-12 sm:h-16 md:h-20 lg:h-24 w-auto object-contain mx-4 md:mx-8 filter grayscale hover:filter-none transition"
                 loading="lazy"
               />
             ))}
           </Marquee>
           <Marquee
+            direction="left"
             speed={30}
             pauseOnHover
             pauseOnClick
             gradient={false}
-            className="flex items-center gap-8"
+            className="flex items-center gap-4 md:gap-8"
           >
             {partnersRow2.map((logo, i) => (
               <img
                 key={i}
                 src={logo}
                 alt={`Partner ${i + partnersRow1.length + 1}`}
-                className="h-20 md:h-24 w-auto object-contain mx-8 filter grayscale hover:filter-none transition"
+                className="h-12 sm:h-16 md:h-20 lg:h-24 w-auto object-contain mx-4 md:mx-8 filter grayscale hover:filter-none transition"
                 loading="lazy"
               />
             ))}

--- a/src/sections/Products.jsx
+++ b/src/sections/Products.jsx
@@ -60,7 +60,7 @@ const products = [
 export default function Products() {
   const [videoLoaded, setVideoLoaded] = useState(false);
   return (
-    <section id="products" className="relative min-h-screen pt-16 pb-12 bg-transparent overflow-hidden">
+    <section id="products" className="relative min-h-screen flex items-center justify-center bg-transparent overflow-hidden">
       {/* hero.mp4 sadece bu bölüm için */}
       <video
         autoPlay

--- a/src/sections/Products.jsx
+++ b/src/sections/Products.jsx
@@ -60,7 +60,7 @@ const products = [
 export default function Products() {
   const [videoLoaded, setVideoLoaded] = useState(false);
   return (
-    <section id="products" className="relative min-h-screen flex items-center justify-center bg-transparent overflow-hidden">
+    <section id="products" className="relative min-h-screen flex items-center justify-center bg-transparent overflow-hidden scroll-mt-16">
       {/* hero.mp4 sadece bu bölüm için */}
       <video
         autoPlay

--- a/src/sections/Services.jsx
+++ b/src/sections/Services.jsx
@@ -51,8 +51,8 @@ const services = [
 
 export default function Services() {
   return (
-    <section id="services" className="min-h-screen flex items-center bg-transparent">
-      <div className="max-w-5xl mx-auto px-6 py-16 text-center">
+    <section id="services" className="min-h-screen flex flex-col justify-center items-center bg-transparent scroll-mt-16">
+      <div className="max-w-5xl mx-auto px-6 text-center">
         <h2 className="text-4xl font-bold mb-8 text-gray-900 dark:text-gray-100">
           Hizmetlerimiz
         </h2>

--- a/src/sections/Services.jsx
+++ b/src/sections/Services.jsx
@@ -51,8 +51,8 @@ const services = [
 
 export default function Services() {
   return (
-    <section id="services" className="min-h-screen py-20 bg-transparent">
-      <div className="max-w-5xl mx-auto px-6 text-center">
+    <section id="services" className="min-h-screen flex items-center bg-transparent">
+      <div className="max-w-5xl mx-auto px-6 py-16 text-center">
         <h2 className="text-4xl font-bold mb-8 text-gray-900 dark:text-gray-100">
           Hizmetlerimiz
         </h2>


### PR DESCRIPTION
## Summary
- ensure theme and language toggles close the mobile menu
- center each section vertically and fill the viewport for cleaner scrolling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68942a413a64832cb9241468204d5b98