### PR TITLE
feat: refresh bilingual content

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -11,18 +11,56 @@
   },
   "hero": {
     "title": "Building a Productive Future",
-    "subtitle": "World-class bull genetics, sexed semen, embryo transfer—all to boost your herd’s productivity.",
-    "cta": "Explore Our Products"
+    "subtitle": "Premium cattle genetics, sexed semen and embryo services to strengthen your herd.",
+    "cta": "Browse Genetics"
   },
   "products": {
-    "title": "Our Products",
-    "item": "Product {{number}}",
-    "description": "Detailed service description here."
+    "title": "Genetic Portfolio",
+    "list": [
+      {
+        "name": "Holstein Heifer",
+        "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Holstein_Friesian_UK_Yorkshire_July_2011.jpg/960px-Holstein_Friesian_UK_Yorkshire_July_2011.jpg",
+        "desc": "High-output Holstein heifer lines for dairy efficiency."
+      },
+      {
+        "name": "Holstein Bull",
+        "image": "https://images.unsplash.com/photo-1527153857715-3908f2bae5e8?auto=compress&cs=tinysrgb&w=800",
+        "desc": "Proven Holstein sires selected for milk quality and longevity."
+      },
+      {
+        "name": "Brown Swiss",
+        "image": "https://upload.wikimedia.org/wikipedia/commons/e/e9/Brown_swiss.jpg",
+        "desc": "Robust Brown Swiss genetics with strong feet and legs."
+      },
+      {
+        "name": "Simmental",
+        "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a6/Simmentaler_Fleckvieh.jpg/960px-Simmentaler_Fleckvieh.jpg",
+        "desc": "Dual-purpose Simmental lines for meat and milk balance."
+      }
+    ]
   },
   "blog": {
-    "title": "Latest Posts",
-    "post": "Blog Title {{number}}",
-    "excerpt": "Short excerpt goes here.",
+    "title": "News & Updates",
+    "posts": [
+      {
+        "title": "New Approaches to AI Breeding",
+        "img": "https://images.unsplash.com/photo-1631651361952-4505762bedcc?auto=compress&cs=tinysrgb&w=800",
+        "excerpt": "How digital tools are reshaping insemination programs.",
+        "link": "#"
+      },
+      {
+        "title": "Farm Health Monitoring",
+        "img": "https://images.unsplash.com/photo-1530268782463-418534b0affa?auto=compress&cs=tinysrgb&w=800",
+        "excerpt": "Track herd wellness to catch issues early.",
+        "link": "#"
+      },
+      {
+        "title": "Genetic Selection Strategies",
+        "img": "https://images.unsplash.com/photo-1532187863486-abf9dbad1b69?auto=compress&cs=tinysrgb&w=800",
+        "excerpt": "Choosing sires that improve milk and meat yield.",
+        "link": "#"
+      }
+    ],
     "readMore": "Read more"
   },
   "partners": {
@@ -31,41 +69,49 @@
   },
   "about": {
     "title": "About Us",
-    "description": "Since 2010, DuruGenetik has stood beside farmers at every step—from sire selection to post-calving monitoring. Our goal is to blend scientific innovation with field expertise to build healthy, highly productive herds."
+    "description": "Founded in 2010 in Burdur, DuruGenetik brings world-class livestock genetics and hands-on support to farms across the region."
   },
   "services": {
     "title": "Our Services",
     "list": [
       {
-        "title": "Genetic Consulting",
-        "description": "Expert guidance on herd management and sire selection."
+        "title": "Genetic Planning",
+        "description": "Customized breeding programs backed by genomic analysis."
       },
       {
-        "title": "Sexed Semen",
-        "description": "Certified sexed semen supplies for high conception rates."
+        "title": "Sexed Semen Supply",
+        "description": "Certified female-biased semen for rapid herd growth."
       },
       {
         "title": "Embryo Transfer",
-        "description": "Modern embryo transfer solutions to multiply superior genetics quickly."
+        "description": "High-success embryo transfer with donor and recipient management."
       }
     ]
   },
   "approach": {
-    "title": "The DuruGenetik Approach",
-    "description": "We combine scientific expertise with field experience to prepare your herd for the future.",
-    "points": [
-      "Tailored strategies for every farm",
-      "Ongoing performance monitoring and reporting",
-      "Innovative solutions for sustainable production"
+    "title": "How We Work",
+    "description": "We blend laboratory science with field expertise to elevate herd performance.",
+    "steps": [
+      { "step": "1. Analysis", "desc": "Farm visit and sample collection." },
+      { "step": "2. Evaluation", "desc": "Genetic index calculation and reporting." },
+      { "step": "3. Implementation", "desc": "Artificial insemination with selected genetics." },
+      { "step": "4. Monitoring", "desc": "Regular check-ups and performance tracking." }
     ]
   },
   "contact": {
     "title": "Contact",
+    "addressLabel": "Address",
+    "address": "Hızır İlyas Mah. İ. Zeki Burdurlu Cad. No:75/A, Burdur",
+    "phoneLabel": "Phone",
+    "phone": "0536 298 30 31",
+    "emailLabel": "Email",
+    "email": "info@durugenetik.com",
     "name": "Name",
+    "emailField": "Email",
     "message": "Message",
     "send": "Send"
   },
   "footer": {
-    "developed_by": "Powered by"
+    "developed_by": "Developed by"
   }
 }

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -11,18 +11,56 @@
   },
   "hero": {
     "title": "Verimli Bir Gelecek İnşa Ediyoruz",
-    "subtitle": "Dünya standartlarında boğa genetiği, seksli semen, embriyo transferi—sürü verimliliğinizi artırmak için.",
-    "cta": "Ürünlerimizi Keşfet"
+    "subtitle": "Sürünüzü güçlendirmek için premium sığır genetiği, seksli sperma ve embriyo hizmetleri.",
+    "cta": "Genetikleri İncele"
   },
   "products": {
-    "title": "Ürünlerimiz",
-    "item": "Ürün {{number}}",
-    "description": "Detaylı hizmet açıklaması burada."
+    "title": "Genetik Portföyümüz",
+    "list": [
+      {
+        "name": "Holstein Düve",
+        "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Holstein_Friesian_UK_Yorkshire_July_2011.jpg/960px-Holstein_Friesian_UK_Yorkshire_July_2011.jpg",
+        "desc": "Süt verimliliği yüksek Holstein dişi hatları."
+      },
+      {
+        "name": "Holstein Boğa",
+        "image": "https://images.unsplash.com/photo-1527153857715-3908f2bae5e8?auto=compress&cs=tinysrgb&w=800",
+        "desc": "Süt kalitesi ve uzun ömür için seçilmiş Holstein boğaları."
+      },
+      {
+        "name": "Montofon",
+        "image": "https://upload.wikimedia.org/wikipedia/commons/e/e9/Brown_swiss.jpg",
+        "desc": "Güçlü ayak yapısıyla dayanıklı Montofon genetiği."
+      },
+      {
+        "name": "Simmental",
+        "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a6/Simmentaler_Fleckvieh.jpg/960px-Simmentaler_Fleckvieh.jpg",
+        "desc": "Et ve süt dengesini sağlayan Simmental hatları."
+      }
+    ]
   },
   "blog": {
-    "title": "Son Yazılar",
-    "post": "Yazı Başlığı {{number}}",
-    "excerpt": "Kısa özet buraya.",
+    "title": "Haberler & Güncellemeler",
+    "posts": [
+      {
+        "title": "Yeni Yapay Tohumlama Yaklaşımları",
+        "img": "https://images.unsplash.com/photo-1631651361952-4505762bedcc?auto=compress&cs=tinysrgb&w=800",
+        "excerpt": "Dijital araçlar tohumlama programlarını nasıl dönüştürüyor.",
+        "link": "#"
+      },
+      {
+        "title": "Çiftlikte Sağlık İzleme",
+        "img": "https://images.unsplash.com/photo-1530268782463-418534b0affa?auto=compress&cs=tinysrgb&w=800",
+        "excerpt": "Sürü sağlığını erken tespit için takip yöntemleri.",
+        "link": "#"
+      },
+      {
+        "title": "Genetik Seçim Stratejileri",
+        "img": "https://images.unsplash.com/photo-1532187863486-abf9dbad1b69?auto=compress&cs=tinysrgb&w=800",
+        "excerpt": "Süt ve et verimini artıran boğa seçimi.",
+        "link": "#"
+      }
+    ],
     "readMore": "Devamını oku"
   },
   "partners": {
@@ -31,41 +69,49 @@
   },
   "about": {
     "title": "Hakkımızda",
-    "description": "DuruGenetik, 2010'dan bu yana damızlık seçiminden doğum sonrası takibe kadar her adımda çiftçinin yanında olan bir genetik teknolojileri şirketidir. Amacımız, yüksek verimli ve sağlıklı sürüler oluşturmak için bilimsel yenilikleri pratik deneyimle buluşturmaktır."
+    "description": "2010 yılında Burdur’da kurulan DuruGenetik, Türkiye genelindeki çiftliklere dünya standartlarında hayvan genetiği ve saha desteği sağlar."
   },
   "services": {
     "title": "Hizmetlerimiz",
     "list": [
       {
-        "title": "Genetik Danışmanlık",
-        "description": "Sürü yönetimi ve damızlık seçiminde uzman rehberlik."
+        "title": "Genetik Planlama",
+        "description": "Genomik analizlerle desteklenen özel damızlık programları."
       },
       {
-        "title": "Seksli Semen",
-        "description": "Yüksek gebelik oranları için sertifikalı seksli semen tedariki."
+        "title": "Seksli Sperma Tedariki",
+        "description": "Sürü büyümesini hızlandıran dişi ağırlıklı sperma."
       },
       {
         "title": "Embriyo Transferi",
-        "description": "Üstün genetik potansiyeli hızla çoğaltmak için modern embriyo transferi çözümleri."
+        "description": "Donör ve taşıyıcı yönetimiyle yüksek başarı oranlı embriyo transferi."
       }
     ]
   },
   "approach": {
-    "title": "DuruGenetik Yaklaşımı",
-    "description": "Bilimsel altyapı ve saha deneyimini bir araya getirerek sürülerinizi geleceğe hazırlarız.",
-    "points": [
-      "Çiftçilere özel strateji ve planlama",
-      "Düzenli performans takibi ve raporlama",
-      "Sürdürülebilir üretim için yenilikçi çözümler"
+    "title": "Nasıl Çalışırız",
+    "description": "Laboratuvar bilimi ve saha deneyimini birleştirerek sürü performansını yükseltiriz.",
+    "steps": [
+      { "step": "1. Analiz", "desc": "Çiftlik ziyareti ve numune toplama." },
+      { "step": "2. Değerlendirme", "desc": "Genetik indeks hesaplaması ve raporlama." },
+      { "step": "3. Uygulama", "desc": "Seçilen genetiklerle suni tohumlama." },
+      { "step": "4. İzleme", "desc": "Düzenli kontroller ve performans takibi." }
     ]
   },
   "contact": {
     "title": "İletişim",
+    "addressLabel": "Adres",
+    "address": "Hızır İlyas Mah. İ. Zeki Burdurlu Cad. No:75/A, Burdur",
+    "phoneLabel": "Telefon",
+    "phone": "0536 298 30 31",
+    "emailLabel": "E-posta",
+    "email": "info@durugenetik.com",
     "name": "İsim",
+    "emailField": "E-posta",
     "message": "Mesaj",
     "send": "Gönder"
   },
   "footer": {
-    "developed_by": "Geliştirici"
+    "developed_by": "Geliştiren"
   }
 }

--- a/src/sections/About.jsx
+++ b/src/sections/About.jsx
@@ -1,18 +1,14 @@
 // src/sections/About.jsx
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 export default function About() {
+  const { t } = useTranslation();
   return (
     <section id="aboutus" className="min-h-screen flex flex-col justify-center items-center scroll-mt-16">
       <div className="max-w-4xl mx-auto px-6 space-y-6 text-center">
-        <h2 className="text-4xl font-bold">Hakkımızda</h2>
-        <p className="text-gray-700 dark:text-gray-300">
-          <strong>Duru Genetik</strong> 2010’dan bu yana Burdur merkezli, veteriner medikal ve hayvan genetiği alanında uzman bir kuruluş. Çiftçilere
-          sürdürülebilir, verimli ve kârlı ırk yönetimi çözümleri sunuyoruz.
-        </p>
-        <p className="text-gray-700 dark:text-gray-300">
-          Misyonumuz, en yeni genomik teknolojileri Türkiye tarımına transfer ederek çiftliklerin verimini ve hayvan refahını en üst düzeye çıkarmak.
-        </p>
+        <h2 className="text-4xl font-bold">{t("about.title")}</h2>
+        <p className="text-gray-700 dark:text-gray-300">{t("about.description")}</p>
       </div>
     </section>
   );

--- a/src/sections/Approach.jsx
+++ b/src/sections/Approach.jsx
@@ -1,18 +1,14 @@
 // src/sections/Approach.jsx
 import React from "react";
-
-const steps = [
-  { step: "1. Analiz", desc: "Saha ziyareti, kan ve süt örneklerinin alınması" },
-  { step: "2. Değerlendirme", desc: "Genetik indeks hesaplamaları ve raporlama" },
-  { step: "3. Uygulama", desc: "Seçilen genomlarla suni tohumlama planlaması" },
-  { step: "4. Takip", desc: "Dönemsel kontroller ve performans izleme" },
-];
+import { useTranslation } from "react-i18next";
 
 export default function Approach() {
+  const { t } = useTranslation();
+  const steps = t("approach.steps", { returnObjects: true });
   return (
     <section id="approach" className="min-h-screen flex flex-col justify-center items-center bg-transparent scroll-mt-16">
       <div className="max-w-5xl mx-auto px-6">
-        <h2 className="text-4xl font-bold mb-12 text-center">Çalışma Prensibimiz</h2>
+        <h2 className="text-4xl font-bold mb-12 text-center">{t("approach.title")}</h2>
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           {steps.map(({ step, desc }) => (
             <div key={step} className="p-6 bg-white bg-opacity-60 backdrop-blur-md rounded-xl shadow-lg dark:bg-neutral-800 dark:bg-opacity-60">

--- a/src/sections/Blog.jsx
+++ b/src/sections/Blog.jsx
@@ -1,35 +1,17 @@
 // src/sections/Blog.jsx
 import React from "react";
-
-const posts = [
-  {
-    title: "Yeni Suni Tohumlama Teknikleri",
-    img: "https://images.unsplash.com/photo-1631651361952-4505762bedcc?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wxMjA3fDB8MXxzZWFyY2h8Mnx8Y293JTIwdmV0ZXJpbmFyaWFufGVufDB8fHx8MTc1NDYyNDA1N3ww&ixlib=rb-4.1.0&q=80&w=1080",
-    excerpt: "Modern laboratuvar şartlarında verim optimizasyonu...",
-    link: "#"
-  },
-  {
-    title: "Çiftlikte Sağlık Takibi",
-    img: "https://images.unsplash.com/photo-1530268782463-418534b0affa?auto=compress&cs=tinysrgb&w=800",
-    excerpt: "Hayvan sağlığı verilerini düzenli takip ederek hastalıkları erkenden tespit edin...",
-    link: "#"
-  },
-  {
-    title: "Genetik Seçim Stratejileri",
-    img: "https://images.unsplash.com/photo-1532187863486-abf9dbad1b69?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wxMjA3fDB8MXxzZWFyY2h8MjJ8fEROQXxlbnwwfHx8fDE3NTQ2MjQwNjd8MA&ixlib=rb-4.1.0&q=80&w=1080",
-    excerpt: "Irk seçiminin süt ve et verimine etkisi üzerine bilimsel makale özeti...",
-    link: "#"
-  },
-];
+import { useTranslation } from "react-i18next";
 
 export default function Blog() {
+  const { t } = useTranslation();
+  const posts = t("blog.posts", { returnObjects: true });
   return (
     <section id="blog" className="min-h-screen flex flex-col justify-center items-center scroll-mt-16">
       <div className="max-w-5xl mx-auto px-6">
-        <h2 className="text-4xl font-bold mb-8 text-center">Blog & Haberler</h2>
+        <h2 className="text-4xl font-bold mb-8 text-center">{t("blog.title")}</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-          {posts.map(p => (
-              <a key={p.title} href={p.link} className="block bg-white rounded-xl shadow-md overflow-hidden hover:shadow-lg dark:bg-neutral-800">
+          {posts.map((p, idx) => (
+              <a key={idx} href={p.link} className="block bg-white rounded-xl shadow-md overflow-hidden hover:shadow-lg dark:bg-neutral-800">
                 <div className="relative w-full h-48 overflow-hidden border-b-4 border-teal-300 dark:border-teal-600">
                   <img src={p.img} alt={p.title} className="w-full h-full object-cover" loading="lazy" />
                   <div className="absolute inset-0 bg-teal-600/20 dark:bg-teal-500/20 mix-blend-multiply hover:bg-teal-600/10 dark:hover:bg-teal-500/10 transition-colors" />

--- a/src/sections/Contact.jsx
+++ b/src/sections/Contact.jsx
@@ -1,39 +1,39 @@
 // src/sections/Contact.jsx
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 export default function Contact() {
+  const { t } = useTranslation();
   return (
     <section id="contact" className="min-h-screen flex flex-col justify-center items-center bg-transparent scroll-mt-16">
       <div className="max-w-3xl mx-auto px-6 text-gray-900 dark:text-gray-100">
-        <h2 className="text-4xl font-bold mb-8 text-center">
-          İletişim
-        </h2>
+        <h2 className="text-4xl font-bold mb-8 text-center">{t("contact.title")}</h2>
         <div className="space-y-4 mb-8">
-          <p><strong>Adres:</strong> Hızır İlyas Mah. İ. Zeki Burdurlu Cad. No:75/A, Burdur</p>
-          <p><strong>Telefon:</strong> 0536 298 30 31</p>
-          <p><strong>Email:</strong> osmanacar@durugenetik.com</p>
+          <p><strong>{t("contact.addressLabel")}:</strong> {t("contact.address")}</p>
+          <p><strong>{t("contact.phoneLabel")}:</strong> {t("contact.phone")}</p>
+          <p><strong>{t("contact.emailLabel")}:</strong> {t("contact.email")}</p>
         </div>
         <form className="grid grid-cols-1 gap-4">
           <input
             type="text"
-            placeholder="Adınız Soyadınız"
+            placeholder={t("contact.name")}
             className="p-4 bg-white bg-opacity-60 backdrop-blur-md rounded-xl shadow-lg dark:bg-neutral-800 dark:bg-opacity-80 placeholder-gray-400 focus:ring-2 focus:ring-green-600"
           />
           <input
             type="email"
-            placeholder="Email Adresiniz"
+            placeholder={t("contact.emailField")}
             className="p-4 bg-white bg-opacity-60 backdrop-blur-md rounded-xl shadow-lg dark:bg-neutral-800 dark:bg-opacity-80 placeholder-gray-400 focus:ring-2 focus:ring-green-600"
           />
           <textarea
             rows="4"
-            placeholder="Mesajınız"
+            placeholder={t("contact.message")}
             className="p-4 bg-white bg-opacity-60 backdrop-blur-md rounded-xl shadow-lg dark:bg-neutral-800 dark:bg-opacity-80 placeholder-gray focus:ring-2 focus:ring-green-600"
           />
           <button
             type="submit"
             className="px-6 py-3 bg-teal-700 hover:bg-green-800 dark:bg-green-300 dark:hover:bg-teal-400 text-white dark:text-gray-800 rounded-xl transition"
           >
-            Gönder
+            {t("contact.send")}
           </button>
         </form>
       </div>

--- a/src/sections/Partners.jsx
+++ b/src/sections/Partners.jsx
@@ -1,6 +1,7 @@
 // src/sections/Partners.jsx
 import React from "react";
 import Marquee from "react-fast-marquee";
+import { useTranslation } from "react-i18next";
 
 const partnersRow1 = [
   "https://logo.clearbit.com/bayer.com?size=256",
@@ -21,13 +22,14 @@ const partnersRow2 = [
 ];
 
 export default function Partners() {
+  const { t } = useTranslation();
   return (
     <section
       id="partners"
       className="min-h-screen flex flex-col justify-center items-center bg-transparent scroll-mt-16"
     >
       <div className="w-full px-4 sm:px-6 text-center">
-        <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-12">İş Ortaklarımız</h2>
+        <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-12">{t("partners.title")}</h2>
         <div className="flex flex-col gap-6 md:gap-8">
           <Marquee
             direction="right"

--- a/src/sections/Products.jsx
+++ b/src/sections/Products.jsx
@@ -1,63 +1,10 @@
 // src/sections/Products.jsx
 import React, { useState } from "react";
-
-const products = [
-  {
-    name: "Holstein Dişi",
-    image:
-      "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Holstein_Friesian_UK_Yorkshire_July_2011.jpg/960px-Holstein_Friesian_UK_Yorkshire_July_2011.jpg",
-    desc: "Yüksek verimli Holstein dişi genomları.",
-  },
-  {
-    name: "Holstein",
-    image:
-      "https://images.unsplash.com/photo-1527153857715-3908f2bae5e8?auto=compress&cs=tinysrgb&w=800",
-    desc: "Dünyaca ünlü süt verimi taçlı Holstein hattı.",
-  },
-  {
-    name: "Montbéliarde",
-    image:
-      "https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Vache_Montb%C3%A9liarde.jpg/960px-Vache_Montb%C3%A9liarde.jpg",
-    desc: "Sağlam dizi ve yüksek süt verimi için Montbéliarde.",
-  },
-  {
-    name: "Montbéliarde Dişi",
-    image:
-      "https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Vache_Montb%C3%A9liarde.jpg/1200px-Vache_Montb%C3%A9liarde.jpg",
-    desc: "Seçkin Montbéliarde dişi genomları.",
-  },
-  {
-    name: "Brown Swiss (Montofon)",
-    image: "https://upload.wikimedia.org/wikipedia/commons/e/e9/Brown_swiss.jpg",
-    desc: "Dayanıklı Brown Swiss (Montofon) genomları.",
-  },
-  {
-    name: "Etçi Boğalar",
-    image:
-      "https://upload.wikimedia.org/wikipedia/commons/b/b5/A_Friesian_Bull%2C_Llandeilo_Graban_-_geograph.org.uk_-_579885.jpg",
-    desc: "En iyi etçi boğalarla damızlık iyileştirme.",
-  },
-  {
-    name: "Kırmızı Holstein",
-    image:
-      "https://images.unsplash.com/photo-1561043394-9f7d16d9ae37?auto=compress&cs=tinysrgb&w=800",
-    desc: "Güçlü ve renkli Kırmızı Holstein genomları.",
-  },
-  {
-    name: "Jersey",
-    image:
-      "https://upload.wikimedia.org/wikipedia/commons/thumb/5/55/Bou%C3%ABts_d%27J%C3%A8rri_%C3%8Agypte_5_J%C3%A8rri_Mai_2009.jpg/960px-Bou%C3%ABts_d%27J%C3%A8rri_Mai_2009.jpg",
-    desc: "Yoğun yağlı süt için seçkin Jersey hattı.",
-  },
-  {
-    name: "Simmental",
-    image:
-      "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a6/Simmentaler_Fleckvieh.jpg/960px-Simmentaler_Fleckvieh.jpg",
-    desc: "Çift yönlü verim: Et & süt için Simmental.",
-  },
-];
+import { useTranslation } from "react-i18next";
 
 export default function Products() {
+  const { t } = useTranslation();
+  const products = t("products.list", { returnObjects: true });
   const [videoLoaded, setVideoLoaded] = useState(false);
   return (
     <section id="products" className="relative min-h-screen flex items-center justify-center bg-transparent overflow-hidden scroll-mt-16">
@@ -83,9 +30,7 @@ export default function Products() {
       <div className="absolute inset-0 bg-white bg-opacity-60 backdrop-blur-sm dark:bg-neutral-900 dark:bg-opacity-60 -z-10" />
 
       <div className="relative z-10 flex flex-col items-center w-full px-6 py-12">
-        <h2 className="text-4xl font-bold mb-8 text-gray-900 dark:text-white">
-          Ürünlerimiz
-        </h2>
+        <h2 className="text-4xl font-bold mb-8 text-gray-900 dark:text-white">{t("products.title")}</h2>
         <div className="hidden sm:grid grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl w-full mx-auto">
           {products.map((prod) => (
             <div

--- a/src/sections/Services.jsx
+++ b/src/sections/Services.jsx
@@ -1,10 +1,12 @@
 // src/sections/Services.jsx
 import React from "react";
+import { useTranslation } from "react-i18next";
 
-const services = [
-  {
-    title: "Genetik Danışmanlık",
-    icon: (
+export default function Services() {
+  const { t } = useTranslation();
+  const services = t("services.list", { returnObjects: true });
+  const icons = [
+    (
       <svg
         className="w-12 h-12 text-green-800 dark:text-green-300 mb-4"
         fill="none"
@@ -15,11 +17,7 @@ const services = [
         <path d="M12 2v20M2 12h20" />
       </svg>
     ),
-    desc: "Sürüdünüzün genetik potansiyelini açığa çıkarmak için saha analizleri."
-  },
-  {
-    title: "Suni Tohumlama",
-    icon: (
+    (
       <svg
         className="w-12 h-12 text-green-800 dark:text-green-300 mb-4"
         fill="none"
@@ -30,12 +28,8 @@ const services = [
         <path d="M6 12h12M12 6v12" />
       </svg>
     ),
-    desc: "En yeni tekniklerle yüksek verimli damızlık hizmeti."
-  },
-  {
-    title: "Embriyo Transferi",
-    icon: (
-       <svg
+    (
+      <svg
         className="w-12 h-12 text-green-800 dark:text-green-300 mb-4"
         fill="none"
         stroke="currentColor"
@@ -44,29 +38,22 @@ const services = [
       >
         <path d="M6 12h12M12 6v12" />
       </svg>
-    ),
-    desc: "Yüksek başarı oranlı embriyo transfer çözümleri.",
-  },
-];
+    )
+  ];
 
-export default function Services() {
   return (
     <section id="services" className="min-h-screen flex flex-col justify-center items-center bg-transparent scroll-mt-16">
       <div className="max-w-5xl mx-auto px-6 text-center">
-        <h2 className="text-4xl font-bold mb-8 text-gray-900 dark:text-gray-100">
-          Hizmetlerimiz
-        </h2>
+        <h2 className="text-4xl font-bold mb-8 text-gray-900 dark:text-gray-100">{t("services.title")}</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
-          {services.map(({ title, icon, desc }) => (
+          {services.map(({ title, description }, idx) => (
             <div
               key={title}
               className="p-6 bg-white bg-opacity-60 backdrop-blur-md rounded-xl shadow-lg dark:bg-neutral-800 dark:bg-opacity-60"
             >
-              {icon}
-              <h3 className="text-xl font-semibold mb-2 text-gray-900 dark:text-gray-100">
-                {title}
-              </h3>
-              <p className="text-gray-700 dark:text-gray-300">{desc}</p>
+              {icons[idx]}
+              <h3 className="text-xl font-semibold mb-2 text-gray-900 dark:text-gray-100">{title}</h3>
+              <p className="text-gray-700 dark:text-gray-300">{description}</p>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- replace placeholder strings with new bilingual copy across sections
- drive products, services, blog and contact from translation files

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895752183d4832c8a587a22919429ad