### PR TITLE
Synchronize HTML lang attribute with i18n language

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,9 +37,13 @@ export default function App() {
 
   // Language
   const { i18n } = useTranslation();
+  useEffect(() => {
+    document.documentElement.lang = i18n.language;
+  }, [i18n.language]);
   const toggleLang = () => {
     const newLang = i18n.language === "en" ? "tr" : "en";
     i18n.changeLanguage(newLang);
+    document.documentElement.lang = newLang;
   };
 
   // Section scroll & highlight


### PR DESCRIPTION
## Summary
- Sync `<html lang>` with active i18n locale when toggling languages
- Initialize `<html lang>` from i18n on first load

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898801ffebc832cabfee1668b0d51bc