### PR TITLE
Lazy load videos on view with posters

### DIFF
--- a/public/images/dna-placeholder.svg
+++ b/public/images/dna-placeholder.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 9"><rect width="16" height="9" fill="#1a1a1a"/></svg>

--- a/public/images/products-placeholder.svg
+++ b/public/images/products-placeholder.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 9"><rect width="16" height="9" fill="#14532d"/></svg>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -53,22 +53,43 @@ export default function App() {
 
   // Video yüklenme takibi (white flash fix)
   const [videoLoaded, setVideoLoaded] = useState(true);
+  const [loadBgVideo, setLoadBgVideo] = useState(false);
   const videoSrc = "/videos/dna-bg.mp4";
   const placeholderColor = "#1a1a1a"; // dark grey fallback main
   const bgVideoRef = useRef(null);
+
+  // Start loading the background video when the home section nears view
   useEffect(() => {
-    setVideoLoaded(false);
-  }, [videoSrc]);
+    const homeSection = sectionRefs.current["home"]?.current;
+    if (!homeSection) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setLoadBgVideo(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "200px" }
+    );
+
+    observer.observe(homeSection);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (loadBgVideo) setVideoLoaded(false);
+  }, [loadBgVideo]);
 
   // Ensure autoplay on iOS devices
   useEffect(() => {
-    if (bgVideoRef.current) {
+    if (loadBgVideo && bgVideoRef.current) {
       const playPromise = bgVideoRef.current.play();
       if (playPromise?.catch) {
         playPromise.catch(() => {});
       }
     }
-  }, [videoSrc]);
+  }, [loadBgVideo]);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -133,6 +154,8 @@ export default function App() {
         muted
         playsInline
         aria-hidden="true"
+        poster="/images/dna-placeholder.svg"
+        preload="none"
         className="fixed inset-0 w-full h-full object-cover -z-10 pointer-events-none select-none"
         style={{
           filter: darkMode
@@ -142,7 +165,7 @@ export default function App() {
         key={videoSrc}
         onLoadedData={() => setVideoLoaded(true)}
       >
-        <source src={videoSrc} type="video/mp4" />
+        {loadBgVideo && <source src={videoSrc} type="video/mp4" />}
       </video>
 
       <main className="relative z-10 pt-16">

--- a/src/sections/Products.jsx
+++ b/src/sections/Products.jsx
@@ -1,24 +1,55 @@
 // src/sections/Products.jsx
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
 export default function Products() {
   const { t } = useTranslation();
   const products = t("products.list", { returnObjects: true });
-  const [videoLoaded, setVideoLoaded] = useState(false);
+  const [videoLoaded, setVideoLoaded] = useState(true);
+  const [loadVideo, setLoadVideo] = useState(false);
+  const sectionRef = useRef(null);
+  const videoRef = useRef(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setLoadVideo(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "200px" }
+    );
+    if (sectionRef.current) observer.observe(sectionRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (loadVideo) setVideoLoaded(false);
+  }, [loadVideo]);
+
+  useEffect(() => {
+    if (loadVideo && videoRef.current) {
+      const p = videoRef.current.play();
+      if (p?.catch) p.catch(() => {});
+    }
+  }, [loadVideo]);
+
   return (
-    <section id="products" className="relative min-h-screen flex items-center justify-center bg-transparent overflow-hidden scroll-mt-16">
+    <section ref={sectionRef} id="products" className="relative min-h-screen flex items-center justify-center bg-transparent overflow-hidden scroll-mt-16">
       {/* hero.mp4 sadece bu bölüm için */}
       <video
+        ref={videoRef}
         autoPlay
         loop
         muted
         playsInline
-        poster="https://images.unsplash.com/photo-1546445317-29f4545e9d53?auto=compress&cs=tinysrgb&w=1600"
+        poster="/images/products-placeholder.svg"
+        preload="none"
         className="absolute inset-0 w-full h-full object-cover -z-20"
         onLoadedData={() => setVideoLoaded(true)}
       >
-        <source src="/videos/products-bg.mp4" type="video/mp4" />
+        {loadVideo && <source src="/videos/products-bg.mp4" type="video/mp4" />}
       </video>
       {!videoLoaded && (
         <div className="absolute inset-0 flex items-center justify-center z-0 pointer-events-none">


### PR DESCRIPTION
## Summary
- load background video only when the home section nears the viewport
- lazily load products background video and supply lightweight poster
- add tiny SVG placeholders for initial rendering

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689880483138832cb22bfdf8e898aa86